### PR TITLE
Replace redundant paragraph text in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,7 +3,7 @@ version=0.0.2
 author=Alexander Pruss
 maintainer=arpruss <arpruss@gmail.com>
 sentence=Support a vector display via USB serial or WiFI
-paragraph=Support a vector display via USB serial or WiFI
+paragraph=The library interfaces with an Android app that provides the display
 category=Display
 url=https://github.com/arpruss/VectorDisplayArduino
 


### PR DESCRIPTION
The Arduino IDE's Library Manager displays the text defined in the library.properties paragraph field immediately after the sentence text so it's not desirable to duplicate the sentence text in paragraph.